### PR TITLE
Update Schematic to remove unneeded caps and resistors

### DIFF
--- a/KiCad/Control_Room.kicad_sch
+++ b/KiCad/Control_Room.kicad_sch
@@ -5,263 +5,6 @@
 	(uuid "5e4b0adc-dbbb-4c0d-8c17-55a3da555a5d")
 	(paper "A4")
 	(lib_symbols
-		(symbol "Device:C"
-			(pin_numbers hide)
-			(pin_names
-				(offset 0.254)
-			)
-			(exclude_from_sim no)
-			(in_bom yes)
-			(on_board yes)
-			(property "Reference" "C"
-				(at 0.635 2.54 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(justify left)
-				)
-			)
-			(property "Value" "C"
-				(at 0.635 -2.54 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(justify left)
-				)
-			)
-			(property "Footprint" ""
-				(at 0.9652 -3.81 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "Datasheet" "~"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "Description" "Unpolarized capacitor"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "ki_keywords" "cap capacitor"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "ki_fp_filters" "C_*"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(symbol "C_0_1"
-				(polyline
-					(pts
-						(xy -2.032 -0.762) (xy 2.032 -0.762)
-					)
-					(stroke
-						(width 0.508)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -2.032 0.762) (xy 2.032 0.762)
-					)
-					(stroke
-						(width 0.508)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-			)
-			(symbol "C_1_1"
-				(pin passive line
-					(at 0 3.81 270)
-					(length 2.794)
-					(name "~"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "1"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at 0 -3.81 90)
-					(length 2.794)
-					(name "~"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "2"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-			)
-		)
-		(symbol "Device:R"
-			(pin_numbers hide)
-			(pin_names
-				(offset 0)
-			)
-			(exclude_from_sim no)
-			(in_bom yes)
-			(on_board yes)
-			(property "Reference" "R"
-				(at 2.032 0 90)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "Value" "R"
-				(at 0 0 90)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "Footprint" ""
-				(at -1.778 0 90)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "Datasheet" "~"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "Description" "Resistor"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "ki_keywords" "R res resistor"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "ki_fp_filters" "R_*"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(symbol "R_0_1"
-				(rectangle
-					(start -1.016 -2.54)
-					(end 1.016 2.54)
-					(stroke
-						(width 0.254)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-			)
-			(symbol "R_1_1"
-				(pin passive line
-					(at 0 3.81 270)
-					(length 1.27)
-					(name "~"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "1"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at 0 -3.81 90)
-					(length 1.27)
-					(name "~"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "2"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-			)
-		)
 		(symbol "Interface_UART:MAX485E"
 			(exclude_from_sim no)
 			(in_bom yes)
@@ -862,820 +605,438 @@
 		)
 	)
 	(junction
-		(at 146.05 35.56)
+		(at 133.35 41.91)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "09bb9efa-c2bd-410c-828b-c7a9673c89ec")
+		(uuid "0aada545-f4e6-45ea-8704-72ae46f4efab")
 	)
 	(junction
-		(at 132.08 69.85)
+		(at 116.84 57.15)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "1156a59f-e331-4199-b281-f1208f0b9452")
+		(uuid "2fbda633-59f0-4105-8e8c-5468bd437098")
 	)
 	(junction
-		(at 139.7 52.07)
+		(at 140.97 55.88)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "15d85c49-80c2-4c67-a97e-448fc76dd033")
+		(uuid "4d2c69c3-d9e8-416d-8354-5c94063059ca")
 	)
 	(junction
-		(at 101.6 52.07)
+		(at 154.94 55.88)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "19a3fdcf-0ee3-4007-bbb2-2b82fa258183")
+		(uuid "55b48427-1a87-4538-9b3b-34b34975b2ce")
 	)
 	(junction
-		(at 132.08 52.07)
+		(at 144.78 57.15)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "215f1602-2745-49a8-ad19-ec5961b8c4dd")
+		(uuid "5aa3ebd7-01c6-436c-9acd-c1fcc9432f2d")
 	)
 	(junction
-		(at 107.95 40.64)
+		(at 133.35 52.07)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "21ac8443-081d-4fc6-a50d-e91a05c4d9d8")
+		(uuid "5d051d52-276b-465d-a3a6-8a94b04938ca")
 	)
 	(junction
-		(at 170.18 52.07)
+		(at 114.3 57.15)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "2fc13a90-5beb-4337-9774-9d764642b6c4")
+		(uuid "9d05d538-3bf7-43e3-994b-b2d1794da565")
 	)
 	(junction
-		(at 139.7 72.39)
+		(at 160.02 55.88)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "2fcbc296-612c-4a7b-9e77-9b35fd82dc3f")
+		(uuid "a5d39616-37c8-4a9a-8293-a0451659c53a")
 	)
 	(junction
-		(at 140.97 71.12)
+		(at 152.4 55.88)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "41c23b5a-e1df-4a22-980d-53c47a8239f6")
-	)
-	(junction
-		(at 107.95 38.1)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "42c8aca7-9590-4327-a525-d2d104a2ba17")
+		(uuid "e733a25f-68b5-4e17-8001-bc5eda48ff58")
 	)
-	(junction
-		(at 132.08 71.12)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "461d79c4-d516-49ed-b245-5979be5ff280")
-	)
-	(junction
-		(at 115.57 38.1)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "4cda5829-cfba-4a98-a522-593f34259330")
-	)
-	(junction
-		(at 115.57 40.64)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "560a9e33-d792-4eb5-9def-0b052a9da2da")
-	)
-	(junction
-		(at 160.02 39.37)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "76b8e6a8-a087-47c5-846e-b1c6535a6d75")
-	)
-	(junction
-		(at 152.4 40.64)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "8e7a5e1b-7f54-4913-ba38-27d54dcadf7e")
-	)
-	(junction
-		(at 132.08 39.37)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "90775e66-597d-4ffe-84b6-1c2361d7b1b9")
-	)
-	(junction
-		(at 170.18 68.58)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "a602d145-bec1-47de-975d-5659c58235be")
-	)
-	(junction
-		(at 132.08 40.64)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "aa744542-ba6f-4330-819d-48d46a091f95")
-	)
-	(junction
-		(at 132.08 68.58)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "cd61f9d0-0f04-4fec-9078-4dfd933d1777")
-	)
-	(junction
-		(at 139.7 67.31)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "d5814bc7-e5a4-488e-9633-8cabf6311b85")
-	)
-	(junction
-		(at 153.67 35.56)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "e1da1eaa-253a-48fa-a1a9-745371937da5")
-	)
-	(junction
-		(at 147.32 40.64)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "ea312111-15c0-44a7-8cc0-fad2eea00ba8")
-	)
-	(junction
-		(at 170.18 69.85)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "fa5d0b92-4652-4d7c-bf57-cea537b080b7")
-	)
-	(no_connect
-		(at 152.4 39.37)
-		(uuid "193e8381-b118-4d3e-bd0e-b54cc7e7de74")
-	)
-	(no_connect
-		(at 147.32 39.37)
-		(uuid "ea79a6d4-9562-4fd9-b16c-6cf0d7f2578c")
-	)
-	(wire
-		(pts
-			(xy 139.7 66.04) (xy 139.7 67.31)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "08e213af-a426-44c7-ad02-af31c555fe77")
-	)
-	(wire
-		(pts
-			(xy 154.94 62.23) (xy 154.94 67.31)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "09650ef2-8951-49d2-8613-f704d2b0207a")
-	)
-	(wire
-		(pts
-			(xy 114.3 71.12) (xy 132.08 71.12)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "0c07c301-ee7b-4b9f-b8e5-6019f862784a")
-	)
-	(wire
-		(pts
-			(xy 160.02 39.37) (xy 132.08 39.37)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "10259126-b3bc-4eb1-bb4d-b32c35fda8c4")
-	)
-	(wire
-		(pts
-			(xy 144.78 77.47) (xy 144.78 72.39)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "20b7de29-b92b-45b8-a881-4be8db602166")
-	)
-	(wire
-		(pts
-			(xy 149.86 62.23) (xy 149.86 69.85)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "277dc341-99a4-4a9d-b2d6-03149838665d")
-	)
-	(wire
-		(pts
-			(xy 146.05 35.56) (xy 146.05 36.83)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "29e15247-276c-47d0-a08e-241472143951")
-	)
-	(wire
-		(pts
-			(xy 139.7 72.39) (xy 101.6 72.39)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "2d63d65f-bbe7-4fa6-af2e-63fafa8cf00c")
-	)
-	(wire
-		(pts
-			(xy 146.05 29.21) (xy 146.05 35.56)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "2dbe9afe-226a-4759-82d9-bcc230f5a3b7")
-	)
-	(wire
-		(pts
-			(xy 140.97 71.12) (xy 170.18 71.12)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "3582e610-8c0b-4db9-8eda-692dfbd7fe52")
-	)
-	(wire
-		(pts
-			(xy 152.4 62.23) (xy 152.4 68.58)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "43c7663b-f3e3-49f6-8093-a505fc3e048d")
-	)
-	(wire
-		(pts
-			(xy 139.7 67.31) (xy 139.7 72.39)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "459e1d99-1ffd-441f-824f-4aec7c753ed7")
-	)
-	(wire
-		(pts
-			(xy 139.7 52.07) (xy 139.7 58.42)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "489de0fc-1837-4c4f-9610-226539a8df9f")
-	)
-	(wire
-		(pts
-			(xy 115.57 29.21) (xy 115.57 38.1)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "50d42c30-ab79-4944-89f0-2144c66b01b4")
-	)
-	(wire
-		(pts
-			(xy 160.02 62.23) (xy 160.02 74.93)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "5400b6f2-d8bd-4fb9-a6e1-260a3a829f23")
-	)
-	(wire
-		(pts
-			(xy 111.76 73.66) (xy 137.16 73.66)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "555409b2-285f-400e-8a0d-44d7936d1003")
-	)
-	(wire
-		(pts
-			(xy 123.19 40.64) (xy 132.08 40.64)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "5d9de9f3-1c85-4c3f-828e-39c2a0cee93f")
-	)
-	(wire
-		(pts
-			(xy 148.59 67.31) (xy 154.94 67.31)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "605adf29-5a35-4b42-a3bd-650f6f666980")
-	)
-	(wire
-		(pts
-			(xy 139.7 40.64) (xy 139.7 52.07)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "63854830-d57f-4919-8ec8-5a8e22ca6319")
-	)
-	(wire
-		(pts
-			(xy 111.76 62.23) (xy 111.76 73.66)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "63db2cd3-3df8-456c-9aac-6652ffb69f3b")
-	)
-	(wire
-		(pts
-			(xy 137.16 73.66) (xy 137.16 77.47)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "645c44ca-bc9b-4853-9e59-2fa16f74ed0d")
-	)
-	(wire
-		(pts
-			(xy 147.32 36.83) (xy 147.32 40.64)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "69e6f726-0159-45d4-b5f6-c030e7f8cd06")
-	)
-	(wire
-		(pts
-			(xy 170.18 39.37) (xy 160.02 39.37)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "6b1e284f-e07f-43c3-84db-5cab7f982f1e")
-	)
-	(wire
-		(pts
-			(xy 152.4 40.64) (xy 152.4 41.91)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "6c63ac0b-b522-46ef-b3e8-de8a421a57ab")
-	)
-	(wire
-		(pts
-			(xy 114.3 62.23) (xy 114.3 71.12)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "6e0b028d-7a27-4ac8-9d91-eb86f5ded446")
-	)
-	(wire
-		(pts
-			(xy 170.18 53.34) (xy 170.18 52.07)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "7a0cfa10-2456-4e58-b942-a6940399ab8d")
-	)
-	(wire
-		(pts
-			(xy 170.18 71.12) (xy 170.18 69.85)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "7a72520f-8fbf-415b-b096-c142f7ce7dc2")
-	)
-	(wire
-		(pts
-			(xy 132.08 39.37) (xy 132.08 40.64)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "81537292-5577-4031-a65f-e4a0758ccf82")
-	)
-	(wire
-		(pts
-			(xy 160.02 74.93) (xy 133.35 74.93)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "854084d1-b62e-4c86-9af2-c00b479de495")
-	)
 	(wire
 		(pts
-			(xy 153.67 29.21) (xy 153.67 35.56)
+			(xy 170.18 55.88) (xy 160.02 55.88)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "86321992-aad4-4af5-99ae-47109bec61b6")
+		(uuid "01f9ae18-045e-4177-875c-793e15b4f0a0")
 	)
 	(wire
 		(pts
-			(xy 115.57 40.64) (xy 115.57 41.91)
+			(xy 116.84 57.15) (xy 144.78 57.15)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "86c57fcf-62ae-40a3-a5d8-8145b9f32646")
+		(uuid "033b25a3-4caf-4610-9200-15037890348e")
 	)
 	(wire
 		(pts
-			(xy 147.32 40.64) (xy 147.32 41.91)
+			(xy 133.35 29.21) (xy 133.35 41.91)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "8a20490b-de31-4632-a7be-7856b2da4dba")
+		(uuid "05e37025-2f48-4bf1-bc5f-79d74d754093")
 	)
 	(wire
 		(pts
-			(xy 121.92 62.23) (xy 121.92 68.58)
+			(xy 133.35 52.07) (xy 140.97 52.07)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "90dada6b-3e46-4f6a-bba1-39358d905e78")
+		(uuid "083fa322-dcf0-4040-977b-dc4c63b50452")
 	)
 	(wire
 		(pts
-			(xy 140.97 71.12) (xy 132.08 71.12)
+			(xy 109.22 29.21) (xy 109.22 31.75)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "93f6060c-c823-4d7b-920c-e85b3dba95cb")
+		(uuid "0e787a7d-1498-4858-b3ef-25290a0304e9")
 	)
 	(wire
 		(pts
-			(xy 144.78 72.39) (xy 139.7 72.39)
+			(xy 154.94 52.07) (xy 154.94 55.88)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "986850f0-f649-4dcc-958b-0faed49e1cbd")
+		(uuid "10cfb541-9b1c-43d6-92ae-b8320835361c")
 	)
 	(wire
 		(pts
-			(xy 107.95 38.1) (xy 107.95 40.64)
+			(xy 152.4 52.07) (xy 152.4 55.88)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "98b0ede9-a36d-48f7-afc6-5cf19a153179")
+		(uuid "1d2d9f93-7b91-4ceb-9ad3-3cc7bb253bd9")
 	)
 	(wire
 		(pts
-			(xy 132.08 29.21) (xy 132.08 39.37)
+			(xy 101.6 57.15) (xy 114.3 57.15)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "98d95220-085a-4bdb-bdeb-55a5d915c5bf")
+		(uuid "22040cea-ccb5-4dd9-9982-e7ce050f1a78")
 	)
 	(wire
 		(pts
-			(xy 170.18 52.07) (xy 170.18 39.37)
+			(xy 140.97 55.88) (xy 140.97 60.96)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "996d8e87-129c-433a-80e9-acd9fe6bd4eb")
+		(uuid "37cccb23-8697-4eea-9e7a-15459ddd2dd3")
 	)
 	(wire
 		(pts
-			(xy 160.02 39.37) (xy 160.02 40.64)
+			(xy 111.76 52.07) (xy 111.76 54.61)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "9f30605e-8d8f-4fbb-8694-dba605c084a3")
+		(uuid "429eb3e6-a0aa-4db4-abf7-8560b63a598b")
 	)
 	(wire
 		(pts
-			(xy 152.4 68.58) (xy 170.18 68.58)
+			(xy 132.08 41.91) (xy 133.35 41.91)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "a316494d-560b-44f0-8e81-a934bb1ff822")
+		(uuid "4b49bac2-b01e-41b9-b979-8f5c4dfb9b27")
 	)
 	(wire
 		(pts
-			(xy 116.84 62.23) (xy 116.84 69.85)
+			(xy 130.81 54.61) (xy 130.81 52.07)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "a4957974-d6c9-47f5-9432-6c3a75919532")
+		(uuid "4c252a76-5afb-4598-88bd-cacbb32c6ee1")
 	)
 	(wire
 		(pts
-			(xy 132.08 68.58) (xy 132.08 63.5)
+			(xy 154.94 55.88) (xy 152.4 55.88)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "a5ed232d-ac64-434c-979a-bab2dbcb5ea5")
+		(uuid "4fe4f82c-08ba-4100-a439-789fc4534d5a")
 	)
 	(wire
 		(pts
-			(xy 101.6 67.31) (xy 101.6 72.39)
+			(xy 147.32 29.21) (xy 147.32 31.75)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "a635aaf0-7f7d-42ae-bb5e-2c908570b680")
+		(uuid "57bb9fb4-9df4-421f-8f50-8b245bf7374d")
 	)
 	(wire
 		(pts
-			(xy 146.05 36.83) (xy 147.32 36.83)
+			(xy 152.4 29.21) (xy 152.4 31.75)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "ae61f137-b49e-4f5f-9c5f-b6d2e609b433")
+		(uuid "5c351550-3224-49b1-a56f-40475f457b0b")
 	)
 	(wire
 		(pts
-			(xy 115.57 38.1) (xy 115.57 40.64)
+			(xy 121.92 52.07) (xy 121.92 53.34)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "b171edc2-dbd7-4faf-b0eb-cfd776c216bf")
+		(uuid "5e54add9-adaf-4df6-a852-a76597212bda")
 	)
 	(wire
 		(pts
-			(xy 153.67 36.83) (xy 152.4 36.83)
+			(xy 114.3 52.07) (xy 114.3 57.15)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "b5711179-814e-4fef-a398-eb2ce977a062")
+		(uuid "5fb08fd3-5678-4210-a934-e88b3927762e")
 	)
 	(wire
 		(pts
-			(xy 100.33 40.64) (xy 100.33 52.07)
+			(xy 149.86 52.07) (xy 149.86 54.61)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "b5ff92eb-b48c-4179-b54e-51844e3bb106")
+		(uuid "62c6baf7-161a-4585-af58-6df8bf23e04f")
 	)
 	(wire
 		(pts
-			(xy 132.08 55.88) (xy 132.08 52.07)
+			(xy 170.18 41.91) (xy 170.18 55.88)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "bbc31e05-46c7-48af-8128-99c571469271")
+		(uuid "63e75b2f-365c-4537-aeb8-95a7b5aa2431")
 	)
 	(wire
 		(pts
-			(xy 132.08 40.64) (xy 132.08 52.07)
+			(xy 121.92 53.34) (xy 137.16 53.34)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "c0cf9936-3daa-4f18-b36f-52b1c7dd02c5")
+		(uuid "644b3701-f350-403f-be35-5fc3b04dfaf3")
 	)
 	(wire
 		(pts
-			(xy 121.92 68.58) (xy 132.08 68.58)
+			(xy 144.78 50.8) (xy 144.78 57.15)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "c444fd2a-4927-4f2e-b7b4-ae69a117a72a")
+		(uuid "66e66da5-7079-4653-a4b4-4816adc715d9")
 	)
 	(wire
 		(pts
-			(xy 107.95 40.64) (xy 107.95 41.91)
+			(xy 133.35 54.61) (xy 133.35 60.96)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "c44f911f-6e0c-4566-850a-1c1548762a7f")
+		(uuid "6a8d7aaa-216d-43e0-8bbf-b6df3352d154")
 	)
 	(wire
 		(pts
-			(xy 139.7 67.31) (xy 140.97 67.31)
+			(xy 114.3 57.15) (xy 116.84 57.15)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "c941dbbf-af89-42ac-94d7-bd2b688209d2")
+		(uuid "712306e0-8ff2-4f0c-bc21-ea046ab4cf65")
 	)
 	(wire
 		(pts
-			(xy 132.08 69.85) (xy 132.08 68.58)
+			(xy 111.76 54.61) (xy 130.81 54.61)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "cbb21533-588f-492b-ba1e-6e2caad3e192")
+		(uuid "757dab4f-e96b-42aa-8bff-909fe2108a5c")
 	)
 	(wire
 		(pts
-			(xy 107.95 41.91) (xy 109.22 41.91)
+			(xy 130.81 52.07) (xy 133.35 52.07)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "ce09f7de-4c5e-48aa-800c-0361ededa5b7")
+		(uuid "7777bc57-51d4-40c9-9aee-b56d18bcfb3c")
 	)
 	(wire
 		(pts
-			(xy 101.6 52.07) (xy 101.6 59.69)
+			(xy 160.02 55.88) (xy 154.94 55.88)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "d019a72d-d806-4543-80e6-15fd51cfede0")
+		(uuid "81c94a12-963e-463c-b71f-d87ab42516a9")
 	)
 	(wire
 		(pts
-			(xy 133.35 74.93) (xy 133.35 77.47)
+			(xy 139.7 50.8) (xy 139.7 41.91)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "d111b22b-42cc-432f-a583-525196f51f14")
+		(uuid "938e34de-46ce-4fca-92e6-b3e88470b924")
 	)
 	(wire
 		(pts
-			(xy 115.57 41.91) (xy 114.3 41.91)
+			(xy 116.84 52.07) (xy 116.84 57.15)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "e63d46d9-75fc-40ce-9412-b1a1a1ecf2eb")
+		(uuid "9455cbc6-90c2-4bbe-94e8-6deebf357f3e")
 	)
 	(wire
 		(pts
-			(xy 153.67 35.56) (xy 153.67 36.83)
+			(xy 137.16 53.34) (xy 137.16 60.96)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "e66d8f7c-21eb-4fb8-92d4-b265842db63b")
+		(uuid "a4b42b2f-c273-4c62-a90a-462a8c5d675e")
 	)
 	(wire
 		(pts
-			(xy 100.33 52.07) (xy 101.6 52.07)
+			(xy 140.97 52.07) (xy 140.97 55.88)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "e6a6f964-1313-4648-b8b5-ec6ae24c0eda")
+		(uuid "a60687b7-2f07-4bac-a5cb-af713d8ff19b")
 	)
 	(wire
 		(pts
-			(xy 140.97 77.47) (xy 140.97 71.12)
+			(xy 133.35 41.91) (xy 133.35 52.07)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "e9dcd6cf-d699-4a50-a321-9b623de5f646")
+		(uuid "b80f3887-f412-4f42-b5a6-ddfed323c56f")
 	)
 	(wire
 		(pts
-			(xy 152.4 36.83) (xy 152.4 40.64)
+			(xy 144.78 60.96) (xy 144.78 57.15)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "ec30f4ff-d26f-4cfa-94b2-86de5b4d888a")
+		(uuid "b93a4cb8-2d04-46e7-b7c4-ffd6feea6c2d")
 	)
 	(wire
 		(pts
-			(xy 170.18 69.85) (xy 170.18 68.58)
+			(xy 152.4 55.88) (xy 140.97 55.88)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "edc8421f-9ca1-4767-a1d7-1c783483eb5b")
+		(uuid "bae1a41f-1f2b-4f06-8222-ac298dbcf733")
 	)
 	(wire
 		(pts
-			(xy 116.84 69.85) (xy 132.08 69.85)
+			(xy 144.78 50.8) (xy 139.7 50.8)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "eec8a9ea-0ea2-40f4-b088-2cc898667f0d")
+		(uuid "bae6a340-fc1e-4c27-98ee-8d8f46669d41")
 	)
 	(wire
 		(pts
-			(xy 132.08 71.12) (xy 132.08 69.85)
+			(xy 160.02 52.07) (xy 160.02 55.88)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "f95a2bd9-9837-4e6b-94bb-95ebfa8189a8")
+		(uuid "c4c60ce3-784a-4686-a159-0b4076c06e2a")
 	)
 	(wire
 		(pts
-			(xy 170.18 68.58) (xy 170.18 60.96)
+			(xy 149.86 54.61) (xy 133.35 54.61)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "fb1c2bc5-213b-4bdb-b9ad-9534a1d7e0f2")
+		(uuid "e3514016-00fc-4964-88c5-f410abaf0a07")
 	)
 	(wire
 		(pts
-			(xy 149.86 69.85) (xy 170.18 69.85)
+			(xy 114.3 29.21) (xy 114.3 31.75)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "fc0c6d34-152a-4cda-98a8-8fa31250d777")
+		(uuid "eef0c121-d416-4164-9ca3-ceb546e6c049")
 	)
 	(wire
 		(pts
-			(xy 107.95 29.21) (xy 107.95 38.1)
+			(xy 101.6 57.15) (xy 101.6 41.91)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "fc5523c9-2311-4483-b429-99a0355edfee")
+		(uuid "fc658cba-3e23-44e3-83d8-aca436222451")
 	)
 	(image
 		(at 186.69 173.99)
@@ -5480,7 +4841,7 @@
 	)
 	(global_label "RS485 RX A"
 		(shape input)
-		(at 107.95 29.21 90)
+		(at 109.22 29.21 90)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -5490,7 +4851,7 @@
 		)
 		(uuid "36326cc9-fe1d-4af4-a5d1-1a6348b1402f")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 107.95 14.6135 90)
+			(at 109.22 14.6135 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5502,7 +4863,7 @@
 	)
 	(global_label "Comms GND"
 		(shape input)
-		(at 132.08 29.21 90)
+		(at 133.35 29.21 90)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -5512,7 +4873,7 @@
 		)
 		(uuid "557f3e1f-3a4d-4303-b35a-3d2496ea97eb")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 132.08 14.553 90)
+			(at 133.35 14.553 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5524,7 +4885,7 @@
 	)
 	(global_label "RS485 TX B"
 		(shape input)
-		(at 153.67 29.21 90)
+		(at 152.4 29.21 90)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -5534,7 +4895,7 @@
 		)
 		(uuid "9abcf192-0bcd-4666-834b-cb59b23d5039")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 153.67 14.6135 90)
+			(at 152.4 14.6135 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5546,7 +4907,7 @@
 	)
 	(global_label "RS485 RX B"
 		(shape input)
-		(at 115.57 29.21 90)
+		(at 114.3 29.21 90)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -5556,7 +4917,7 @@
 		)
 		(uuid "afacd92f-f260-453c-965e-7088abcc1f14")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 115.57 14.6135 90)
+			(at 114.3 14.6135 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5568,7 +4929,7 @@
 	)
 	(global_label "RS485 TX A"
 		(shape input)
-		(at 146.05 29.21 90)
+		(at 147.32 29.21 90)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -5578,7 +4939,7 @@
 		)
 		(uuid "d69c69ab-e4e3-4755-93dc-cf6a2bd63707")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 146.05 14.6135 90)
+			(at 147.32 14.6135 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5589,556 +4950,8 @@
 		)
 	)
 	(symbol
-		(lib_id "Device:R")
-		(at 144.78 67.31 270)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(uuid "0087b398-5fb4-433e-9eb4-3830cd927aee")
-		(property "Reference" "R15"
-			(at 144.78 69.596 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Value" "10k"
-			(at 144.78 67.31 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 144.78 65.532 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 144.78 67.31 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Resistor"
-			(at 144.78 67.31 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "2"
-			(uuid "bc9030d2-4f86-4774-833b-dd695cbe33ee")
-		)
-		(pin "1"
-			(uuid "7af6e695-c843-461f-8413-8b9281c72c54")
-		)
-		(instances
-			(project "Systems&Electronics"
-				(path "/4e05caf8-77e4-4a22-9a05-51fcca8e50ff/b15947ff-9075-4e47-b24b-e604669a88aa"
-					(reference "R15")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "Device:R")
-		(at 132.08 59.69 180)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "1619aebf-f05c-45c5-bf0d-beb9a8f1d40c")
-		(property "Reference" "R13"
-			(at 134.62 58.4199 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Value" "10k"
-			(at 134.62 60.9599 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Footprint" ""
-			(at 133.858 59.69 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 132.08 59.69 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Resistor"
-			(at 132.08 59.69 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "2"
-			(uuid "47cc3a15-cdec-4017-8cf2-766fb3471197")
-		)
-		(pin "1"
-			(uuid "8b19dd4a-dece-4842-8dd0-6b9108b60cae")
-		)
-		(instances
-			(project "Systems&Electronics"
-				(path "/4e05caf8-77e4-4a22-9a05-51fcca8e50ff/b15947ff-9075-4e47-b24b-e604669a88aa"
-					(reference "R13")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "Device:R")
-		(at 143.51 40.64 90)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "29fd3458-00b2-46d8-9379-b9b18c397655")
-		(property "Reference" "R14"
-			(at 143.51 34.29 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Value" "680"
-			(at 143.51 36.83 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 143.51 42.418 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 143.51 40.64 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Resistor"
-			(at 143.51 40.64 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "b1e8e5ae-036a-44f4-a83c-ea03ce03a390")
-		)
-		(pin "2"
-			(uuid "d0dd35c0-7f2f-46bd-ae0f-ee5575252f23")
-		)
-		(instances
-			(project "Systems&Electronics"
-				(path "/4e05caf8-77e4-4a22-9a05-51fcca8e50ff/b15947ff-9075-4e47-b24b-e604669a88aa"
-					(reference "R14")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "Device:R")
-		(at 156.21 40.64 90)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "2e061fbf-d63c-4608-8c28-eb0a97ab99c2")
-		(property "Reference" "R17"
-			(at 156.21 34.29 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Value" "680"
-			(at 156.21 36.83 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 156.21 42.418 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 156.21 40.64 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Resistor"
-			(at 156.21 40.64 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "20c72068-3149-4f33-ac4a-ae4d478f39c3")
-		)
-		(pin "2"
-			(uuid "cc8c5b98-c7fa-43e2-8a25-b1a0af8f5227")
-		)
-		(instances
-			(project "Systems&Electronics"
-				(path "/4e05caf8-77e4-4a22-9a05-51fcca8e50ff/b15947ff-9075-4e47-b24b-e604669a88aa"
-					(reference "R17")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "Device:R")
-		(at 111.76 38.1 90)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "45519c8d-8cf0-465c-94f3-4e1628b35810")
-		(property "Reference" "R11"
-			(at 111.76 31.75 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Value" "120"
-			(at 111.76 34.29 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 111.76 39.878 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 111.76 38.1 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Resistor"
-			(at 111.76 38.1 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "f0c2edce-616a-4fe1-8e7d-cc6b8fb7abbc")
-		)
-		(pin "2"
-			(uuid "e4bd9ed1-dc93-41c2-8fc8-73e9c62de02f")
-		)
-		(instances
-			(project "Systems&Electronics"
-				(path "/4e05caf8-77e4-4a22-9a05-51fcca8e50ff/b15947ff-9075-4e47-b24b-e604669a88aa"
-					(reference "R11")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "Device:R")
-		(at 149.86 35.56 90)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "595d71a8-2be2-4662-9fbb-a491e66f5dcc")
-		(property "Reference" "R16"
-			(at 149.86 29.21 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Value" "120"
-			(at 149.86 31.75 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 149.86 37.338 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 149.86 35.56 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Resistor"
-			(at 149.86 35.56 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "eba7d6fe-05cc-4446-bd86-a159d65634ca")
-		)
-		(pin "2"
-			(uuid "8b18798c-8ac2-436b-ab21-62721c23f1e3")
-		)
-		(instances
-			(project "Systems&Electronics"
-				(path "/4e05caf8-77e4-4a22-9a05-51fcca8e50ff/b15947ff-9075-4e47-b24b-e604669a88aa"
-					(reference "R16")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "Device:C")
-		(at 101.6 63.5 180)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(uuid "6e900cd5-b62c-47fe-bfb5-a4800b5f8cb0")
-		(property "Reference" "C4"
-			(at 101.6 61.468 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Value" "0.1uF"
-			(at 101.854 65.532 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Footprint" ""
-			(at 100.6348 59.69 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 101.6 63.5 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Unpolarized capacitor"
-			(at 101.6 63.5 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "8ff9da39-ec22-4d13-a226-d5d3ac793776")
-		)
-		(pin "2"
-			(uuid "71afb428-c4e5-4267-a607-38bba968bdfb")
-		)
-		(instances
-			(project "Systems&Electronics"
-				(path "/4e05caf8-77e4-4a22-9a05-51fcca8e50ff/b15947ff-9075-4e47-b24b-e604669a88aa"
-					(reference "C4")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "Device:R")
-		(at 170.18 57.15 180)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "82a66b2e-1c6f-452e-bdcd-6f8ef764a283")
-		(property "Reference" "R18"
-			(at 172.72 55.8799 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Value" "10k"
-			(at 172.72 58.4199 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Footprint" ""
-			(at 171.958 57.15 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 170.18 57.15 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Resistor"
-			(at 170.18 57.15 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "2"
-			(uuid "f73bd3f4-dcf2-445a-aeec-96bd08e81837")
-		)
-		(pin "1"
-			(uuid "90ee747f-1282-40a6-8425-a9735e40c319")
-		)
-		(instances
-			(project "Systems&Electronics"
-				(path "/4e05caf8-77e4-4a22-9a05-51fcca8e50ff/b15947ff-9075-4e47-b24b-e604669a88aa"
-					(reference "R18")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
 		(lib_id "Interface_UART:MAX485E")
-		(at 116.84 52.07 90)
+		(at 116.84 41.91 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -6147,23 +4960,25 @@
 		(fields_autoplaced yes)
 		(uuid "860c07d4-e18f-4e9f-9626-a7e060e90b38")
 		(property "Reference" "U1"
-			(at 135.89 46.5738 90)
+			(at 135.89 36.4138 90)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
+				(hide yes)
 			)
 		)
 		(property "Value" "MAX485E"
-			(at 135.89 49.1138 90)
+			(at 135.89 38.9538 90)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
+				(hide yes)
 			)
 		)
 		(property "Footprint" "Package_SO:SOIC-8_3.9x4.9mm_P1.27mm"
-			(at 139.7 52.07 0)
+			(at 139.7 41.91 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6172,7 +4987,7 @@
 			)
 		)
 		(property "Datasheet" "https://datasheets.maximintegrated.com/en/ds/MAX1487E-MAX491E.pdf"
-			(at 115.57 52.07 0)
+			(at 115.57 41.91 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6181,7 +4996,7 @@
 			)
 		)
 		(property "Description" "Half duplex RS-485/RS-422, 2.5 Mbps, ±15kV electro-static discharge (ESD) protection, no slew-rate, no low-power shutdown, with receiver/driver enable, 32 receiver drive capability, DIP-8 and SOIC-8"
-			(at 116.84 52.07 0)
+			(at 116.84 41.91 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6223,213 +5038,8 @@
 		)
 	)
 	(symbol
-		(lib_id "Device:C")
-		(at 139.7 62.23 180)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(uuid "8b0f3e13-0258-44b8-95e6-651559ecb519")
-		(property "Reference" "C3"
-			(at 139.7 60.198 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Value" "0.1uF"
-			(at 139.954 64.262 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Footprint" ""
-			(at 138.7348 58.42 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 139.7 62.23 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Unpolarized capacitor"
-			(at 139.7 62.23 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "6041c92a-c4fd-4b9e-92d2-fca141b93a8b")
-		)
-		(pin "2"
-			(uuid "ac9acbb6-b4a4-4cfa-b7b0-ba8e89b4c938")
-		)
-		(instances
-			(project "Systems&Electronics"
-				(path "/4e05caf8-77e4-4a22-9a05-51fcca8e50ff/b15947ff-9075-4e47-b24b-e604669a88aa"
-					(reference "C3")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "Device:R")
-		(at 104.14 40.64 90)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "bd9ce14f-4c5a-4f60-9d64-aacf1af1e0c2")
-		(property "Reference" "R10"
-			(at 104.14 34.29 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Value" "680"
-			(at 104.14 36.83 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 104.14 42.418 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 104.14 40.64 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Resistor"
-			(at 104.14 40.64 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "8637a559-3dfc-47a2-b9e7-6c968bb69153")
-		)
-		(pin "2"
-			(uuid "581ca1f7-d2e7-49af-bb0f-48342ed4a615")
-		)
-		(instances
-			(project "Systems&Electronics"
-				(path "/4e05caf8-77e4-4a22-9a05-51fcca8e50ff/b15947ff-9075-4e47-b24b-e604669a88aa"
-					(reference "R10")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "Device:R")
-		(at 119.38 40.64 90)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "d362cdd4-8a7b-40db-b414-1fcea4516f7c")
-		(property "Reference" "R12"
-			(at 119.38 34.29 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Value" "680"
-			(at 119.38 36.83 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 119.38 42.418 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 119.38 40.64 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Resistor"
-			(at 119.38 40.64 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "fe2acd9e-4271-4ed4-b3f1-146a93cab099")
-		)
-		(pin "2"
-			(uuid "10187cf3-519b-4fec-a442-4066c56412f9")
-		)
-		(instances
-			(project "Systems&Electronics"
-				(path "/4e05caf8-77e4-4a22-9a05-51fcca8e50ff/b15947ff-9075-4e47-b24b-e604669a88aa"
-					(reference "R12")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
 		(lib_id "Interface_UART:MAX485E")
-		(at 154.94 52.07 90)
+		(at 154.94 41.91 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -6438,7 +5048,7 @@
 		(fields_autoplaced yes)
 		(uuid "de480514-3b5e-47a9-b078-a16eb1f9bb49")
 		(property "Reference" "U2"
-			(at 173.99 46.5738 90)
+			(at 173.99 36.4138 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6446,7 +5056,7 @@
 			)
 		)
 		(property "Value" "MAX485E"
-			(at 173.99 49.1138 90)
+			(at 173.99 38.9538 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6454,7 +5064,7 @@
 			)
 		)
 		(property "Footprint" "Package_SO:SOIC-8_3.9x4.9mm_P1.27mm"
-			(at 177.8 52.07 0)
+			(at 177.8 41.91 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6463,7 +5073,7 @@
 			)
 		)
 		(property "Datasheet" "https://datasheets.maximintegrated.com/en/ds/MAX1487E-MAX491E.pdf"
-			(at 153.67 52.07 0)
+			(at 153.67 41.91 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6472,7 +5082,7 @@
 			)
 		)
 		(property "Description" "Half duplex RS-485/RS-422, 2.5 Mbps, ±15kV electro-static discharge (ESD) protection, no slew-rate, no low-power shutdown, with receiver/driver enable, 32 receiver drive capability, DIP-8 and SOIC-8"
-			(at 154.94 52.07 0)
+			(at 154.94 41.91 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6515,7 +5125,7 @@
 	)
 	(symbol
 		(lib_id "USB_UART:USB_UART")
-		(at 135.89 92.71 0)
+		(at 135.89 76.2 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -6524,7 +5134,7 @@
 		(fields_autoplaced yes)
 		(uuid "e3f07e22-b5b3-406c-ab34-0fa62bfecba4")
 		(property "Reference" "USB_UART1"
-			(at 149.86 92.0749 0)
+			(at 149.86 75.5649 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6533,7 +5143,7 @@
 			)
 		)
 		(property "Value" "~"
-			(at 149.86 93.98 0)
+			(at 149.86 77.47 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6542,7 +5152,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 135.89 92.71 0)
+			(at 135.89 76.2 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6551,7 +5161,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 135.89 92.71 0)
+			(at 135.89 76.2 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6560,7 +5170,7 @@
 			)
 		)
 		(property "Description" ""
-			(at 135.89 92.71 0)
+			(at 135.89 76.2 0)
 			(effects
 				(font
 					(size 1.27 1.27)

--- a/KiCad/Systems&Electronics.kicad_sch
+++ b/KiCad/Systems&Electronics.kicad_sch
@@ -176,34 +176,31 @@
 				)
 			)
 		)
-		(symbol "Device:C"
+		(symbol "Device:D"
 			(pin_numbers hide)
 			(pin_names
-				(offset 0.254)
-			)
+				(offset 1.016) hide)
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
-			(property "Reference" "C"
-				(at 0.635 2.54 0)
+			(property "Reference" "D"
+				(at 0 2.54 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
-					(justify left)
 				)
 			)
-			(property "Value" "C"
-				(at 0.635 -2.54 0)
+			(property "Value" "D"
+				(at 0 -2.54 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
-					(justify left)
 				)
 			)
 			(property "Footprint" ""
-				(at 0.9652 -3.81 0)
+				(at 0 0 0)
 				(effects
 					(font
 						(size 1.27 1.27)
@@ -220,7 +217,7 @@
 					(hide yes)
 				)
 			)
-			(property "Description" "Unpolarized capacitor"
+			(property "Description" "Diode"
 				(at 0 0 0)
 				(effects
 					(font
@@ -229,7 +226,7 @@
 					(hide yes)
 				)
 			)
-			(property "ki_keywords" "cap capacitor"
+			(property "Sim.Device" "D"
 				(at 0 0 0)
 				(effects
 					(font
@@ -238,7 +235,7 @@
 					(hide yes)
 				)
 			)
-			(property "ki_fp_filters" "C_*"
+			(property "Sim.Pins" "1=K 2=A"
 				(at 0 0 0)
 				(effects
 					(font
@@ -247,13 +244,31 @@
 					(hide yes)
 				)
 			)
-			(symbol "C_0_1"
+			(property "ki_keywords" "diode"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "TO-???* *_Diode_* *SingleDiode* D_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "D_0_1"
 				(polyline
 					(pts
-						(xy -2.032 -0.762) (xy 2.032 -0.762)
+						(xy -1.27 1.27) (xy -1.27 -1.27)
 					)
 					(stroke
-						(width 0.508)
+						(width 0.254)
 						(type default)
 					)
 					(fill
@@ -262,10 +277,22 @@
 				)
 				(polyline
 					(pts
-						(xy -2.032 0.762) (xy 2.032 0.762)
+						(xy 1.27 0) (xy -1.27 0)
 					)
 					(stroke
-						(width 0.508)
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 1.27) (xy 1.27 -1.27) (xy -1.27 0) (xy 1.27 1.27)
+					)
+					(stroke
+						(width 0.254)
 						(type default)
 					)
 					(fill
@@ -273,11 +300,11 @@
 					)
 				)
 			)
-			(symbol "C_1_1"
+			(symbol "D_1_1"
 				(pin passive line
-					(at 0 3.81 270)
-					(length 2.794)
-					(name "~"
+					(at -3.81 0 0)
+					(length 2.54)
+					(name "K"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -293,9 +320,9 @@
 					)
 				)
 				(pin passive line
-					(at 0 -3.81 90)
-					(length 2.794)
-					(name "~"
+					(at 3.81 0 180)
+					(length 2.54)
+					(name "A"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -4459,12 +4486,6 @@
 		(uuid "142a2c40-47f5-42c6-9738-8e2b80fde196")
 	)
 	(junction
-		(at 15.24 45.72)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "17cef836-b29b-487a-aaea-20ba9a987180")
-	)
-	(junction
 		(at 189.23 137.16)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -4489,22 +4510,10 @@
 		(uuid "2d9a8db0-6adc-4662-bdf0-87c1afbf3ea9")
 	)
 	(junction
-		(at 52.07 67.31)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "2e1967c1-887c-455a-9f61-1277f364e358")
-	)
-	(junction
 		(at 12.7 90.17)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "38f236b1-192b-4e79-9dfc-b51347f13f56")
-	)
-	(junction
-		(at 21.59 34.29)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "3ae19c57-cb0c-46af-83ab-2ad6736f3645")
 	)
 	(junction
 		(at 259.08 161.29)
@@ -4523,6 +4532,12 @@
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "4bc082be-f5f4-41e9-adfa-ca1120b177cc")
+	)
+	(junction
+		(at 45.72 53.34)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4bdabb09-8511-4cd3-ad08-1aa6b3867fa8")
 	)
 	(junction
 		(at 12.7 76.2)
@@ -4549,28 +4564,16 @@
 		(uuid "4ef6f10d-d4b2-4a50-b925-5e5b5ccf6c80")
 	)
 	(junction
-		(at 73.66 33.02)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "514b06f6-9022-419d-ac12-4864e933a2c6")
-	)
-	(junction
 		(at 217.17 160.02)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "5819e66c-4f81-4dae-8591-ea35a85e8984")
 	)
 	(junction
-		(at 45.72 45.72)
+		(at 45.72 39.37)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "58bf810f-090e-4dd1-bfcb-39f61ed70b93")
-	)
-	(junction
-		(at 53.34 45.72)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "5bd31495-4e56-4c05-a106-401363339aa6")
 	)
 	(junction
 		(at 13.97 135.89)
@@ -4585,10 +4588,16 @@
 		(uuid "64ad641f-b0af-4c75-aba3-017ec7abd287")
 	)
 	(junction
-		(at 45.72 34.29)
+		(at 45.72 55.88)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "6b49dc95-aa41-4bfd-a6e9-7fb95e563620")
+		(uuid "64c8a33d-0a1a-4d68-a326-d3b042cd1801")
+	)
+	(junction
+		(at 53.34 67.31)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "659fb500-7d70-4881-a5e6-d279b7b5d957")
 	)
 	(junction
 		(at 259.08 134.62)
@@ -4609,12 +4618,6 @@
 		(uuid "793c4fe3-515a-4dd7-b2a7-30c6bfdaa7ee")
 	)
 	(junction
-		(at 45.72 62.23)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "7e7133a2-a67c-4a8e-8a17-8beb31358367")
-	)
-	(junction
 		(at 199.39 73.66)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -4627,28 +4630,28 @@
 		(uuid "825b32f1-2b28-439e-9c2b-133c7dc7633a")
 	)
 	(junction
-		(at 66.04 34.29)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "890a28d1-96da-4c8a-aef1-b8a73b68f27e")
-	)
-	(junction
 		(at 119.38 185.42)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "8ab7a7c4-2195-42a1-93e1-32210ebd28de")
 	)
 	(junction
-		(at 83.82 45.72)
+		(at 45.72 54.61)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "8f064684-60b2-46e5-8098-6f94c5d76221")
+		(uuid "8fa9a6e2-ace2-460c-a331-99c357ea35ff")
 	)
 	(junction
 		(at 271.78 161.29)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "92690f0c-1be0-4c19-877e-b97987a77c79")
+	)
+	(junction
+		(at 83.82 54.61)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "962baa58-754c-4ff2-a034-63aa9f45dcd6")
 	)
 	(junction
 		(at 251.46 107.95)
@@ -4663,6 +4666,12 @@
 		(uuid "99c2ccce-03cb-4359-a4f1-fd1db0a2cd4d")
 	)
 	(junction
+		(at 66.04 55.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9b315d16-304d-4626-8e48-fa9cb2d4d9f7")
+	)
+	(junction
 		(at 194.31 161.29)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -4673,12 +4682,6 @@
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "a10e27e4-0989-4d8a-8692-07348d80ca04")
-	)
-	(junction
-		(at 45.72 33.02)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "a48caaa6-3c28-4f54-8d9a-6235cb9c9feb")
 	)
 	(junction
 		(at 250.19 161.29)
@@ -4693,22 +4696,16 @@
 		(uuid "b4be128d-6a25-41c3-9e0d-5a97f84194fb")
 	)
 	(junction
-		(at 60.96 34.29)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "b8a40ead-c25b-4f21-894a-ae8e83597080")
-	)
-	(junction
-		(at 21.59 31.75)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "bcf79cc2-59c8-4214-a7b3-1a9e820f3997")
-	)
-	(junction
 		(at 12.7 118.11)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "c338452f-eac7-4fee-ad5a-ba0b5bc6a84f")
+	)
+	(junction
+		(at 53.34 55.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c8995f72-8146-4bfe-a67b-42c4b5c079a6")
 	)
 	(junction
 		(at 49.53 156.21)
@@ -4717,28 +4714,10 @@
 		(uuid "c8d4f0ed-f85a-4060-b330-28d5eed16857")
 	)
 	(junction
-		(at 45.72 63.5)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "d037dbfd-b4da-4052-a5a9-1664c4b1b178")
-	)
-	(junction
-		(at 59.69 29.21)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "d95eddda-583f-4af5-ae4e-c0bd6a20cb92")
-	)
-	(junction
 		(at 66.04 154.94)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "da924484-7f1f-413f-99a4-299b7cc3fe0a")
-	)
-	(junction
-		(at 29.21 31.75)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "daa39121-85ef-4f1c-bb93-9a5d8227dba3")
 	)
 	(junction
 		(at 231.14 134.62)
@@ -4781,46 +4760,6 @@
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "eeafc4d8-83e5-4130-9c51-1d0b27caa3a1")
-	)
-	(junction
-		(at 67.31 29.21)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "efd39afc-67a0-462b-8c54-bbac651d6daf")
-	)
-	(junction
-		(at 83.82 62.23)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "f1d946ec-06e6-4c77-bc39-7b3addc370fc")
-	)
-	(junction
-		(at 29.21 34.29)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "fb7dceff-8e81-4f97-b7e6-a6293c832cdc")
-	)
-	(junction
-		(at 53.34 60.96)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "fbce88a9-8099-4ae1-858c-3ad6fe7a76ee")
-	)
-	(no_connect
-		(at 60.96 33.02)
-		(uuid "1883cdc2-bcae-4def-bde0-0038bdf27c36")
-	)
-	(no_connect
-		(at 90.17 55.88)
-		(uuid "3e3f040c-f0a7-41e5-bc9f-cfbd6d7756fe")
-	)
-	(no_connect
-		(at 66.04 33.02)
-		(uuid "726c5ef0-59ec-4193-8d16-a218b80bf047")
-	)
-	(no_connect
-		(at 52.07 66.04)
-		(uuid "9a8b5a18-d5ca-4b16-bef3-27703ae5de0c")
 	)
 	(wire
 		(pts
@@ -4874,16 +4813,6 @@
 	)
 	(wire
 		(pts
-			(xy 67.31 30.48) (xy 66.04 30.48)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "0412852e-b3e7-43fa-b009-798ea4e4b36a")
-	)
-	(wire
-		(pts
 			(xy 170.18 80.01) (xy 160.02 80.01)
 		)
 		(stroke
@@ -4891,16 +4820,6 @@
 			(type default)
 		)
 		(uuid "05c25e8a-46c8-49eb-908d-4f2d4220489b")
-	)
-	(wire
-		(pts
-			(xy 29.21 35.56) (xy 27.94 35.56)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "05c6ce58-f0b4-44e6-97c2-f17112408676")
 	)
 	(wire
 		(pts
@@ -4954,16 +4873,6 @@
 	)
 	(wire
 		(pts
-			(xy 27.94 64.77) (xy 45.72 64.77)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "0ae5b224-a24d-4129-9f5f-b995372afb2b")
-	)
-	(wire
-		(pts
 			(xy 194.31 49.53) (xy 194.31 52.07)
 		)
 		(stroke
@@ -4994,16 +4903,6 @@
 	)
 	(wire
 		(pts
-			(xy 83.82 63.5) (xy 83.82 62.23)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "0c2cdcfc-c7bb-4442-942e-1291fd41ae4a")
-	)
-	(wire
-		(pts
 			(xy 177.8 134.62) (xy 203.2 134.62)
 		)
 		(stroke
@@ -5031,26 +4930,6 @@
 			(type default)
 		)
 		(uuid "0e956419-e1e0-4fda-bd5f-09808be3eba0")
-	)
-	(wire
-		(pts
-			(xy 53.34 34.29) (xy 53.34 45.72)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "0f87359c-e952-4e5f-8492-64dcf30b5bdb")
-	)
-	(wire
-		(pts
-			(xy 60.96 30.48) (xy 60.96 34.29)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "0ff4429a-2515-4017-862c-adfab747ea79")
 	)
 	(wire
 		(pts
@@ -5121,16 +5000,6 @@
 			(type default)
 		)
 		(uuid "1ac5594f-0e69-4cb3-99d9-9fe0333a6e1e")
-	)
-	(wire
-		(pts
-			(xy 35.56 62.23) (xy 45.72 62.23)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "1b16454f-186f-4ea9-9448-015e689e2474")
 	)
 	(wire
 		(pts
@@ -5274,16 +5143,6 @@
 	)
 	(wire
 		(pts
-			(xy 30.48 55.88) (xy 30.48 63.5)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "2526fa92-7aaf-4eaf-9bee-ab14d5aebf45")
-	)
-	(wire
-		(pts
 			(xy 49.53 156.21) (xy 67.31 156.21)
 		)
 		(stroke
@@ -5301,16 +5160,6 @@
 			(type default)
 		)
 		(uuid "2613ed05-17ee-48eb-9bac-7f4dacb829ec")
-	)
-	(wire
-		(pts
-			(xy 62.23 60.96) (xy 68.58 60.96)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "2734824c-7f33-4092-955f-4cc4c501366c")
 	)
 	(wire
 		(pts
@@ -5454,6 +5303,16 @@
 	)
 	(wire
 		(pts
+			(xy 68.58 55.88) (xy 66.04 55.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2d0f4c2e-cc0f-4634-b783-186c423d3dfb")
+	)
+	(wire
+		(pts
 			(xy 13.97 95.25) (xy 13.97 109.22)
 		)
 		(stroke
@@ -5461,26 +5320,6 @@
 			(type default)
 		)
 		(uuid "2eb78fbe-824b-48c5-8d23-0e0dc23d43be")
-	)
-	(wire
-		(pts
-			(xy 90.17 66.04) (xy 90.17 49.53)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "2f25f502-1309-472d-992c-81d82a9e0d88")
-	)
-	(wire
-		(pts
-			(xy 67.31 29.21) (xy 67.31 30.48)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "2f61c61b-faf6-46de-b7e2-7827e2162455")
 	)
 	(wire
 		(pts
@@ -5504,6 +5343,16 @@
 	)
 	(wire
 		(pts
+			(xy 53.34 67.31) (xy 91.44 67.31)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "31e9f0d3-e315-40e0-94ea-b271a6ce9b08")
+	)
+	(wire
+		(pts
 			(xy 250.19 153.67) (xy 250.19 161.29)
 		)
 		(stroke
@@ -5524,6 +5373,16 @@
 	)
 	(wire
 		(pts
+			(xy 27.94 49.53) (xy 27.94 55.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "33badd53-0a22-4619-af09-f6fb2a2164a3")
+	)
+	(wire
+		(pts
 			(xy 245.11 137.16) (xy 245.11 138.43)
 		)
 		(stroke
@@ -5531,26 +5390,6 @@
 			(type default)
 		)
 		(uuid "3489ab54-22c6-4a02-9ee8-6a5c4da808a5")
-	)
-	(wire
-		(pts
-			(xy 53.34 60.96) (xy 54.61 60.96)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "349c8c24-f88d-4340-9984-89634d5ba557")
-	)
-	(wire
-		(pts
-			(xy 68.58 55.88) (xy 68.58 60.96)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "35326ca2-9f91-4e3a-9992-053cd8b6e4f4")
 	)
 	(wire
 		(pts
@@ -5594,16 +5433,6 @@
 	)
 	(wire
 		(pts
-			(xy 45.72 63.5) (xy 45.72 62.23)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "38a70187-2909-468a-ba3d-04090832d9d5")
-	)
-	(wire
-		(pts
 			(xy 194.31 138.43) (xy 194.31 133.35)
 		)
 		(stroke
@@ -5624,16 +5453,6 @@
 	)
 	(wire
 		(pts
-			(xy 13.97 45.72) (xy 15.24 45.72)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "3bdc9bc1-cd62-4b31-b617-a4a8f3e52f17")
-	)
-	(wire
-		(pts
 			(xy 248.92 81.28) (xy 251.46 81.28)
 		)
 		(stroke
@@ -5644,16 +5463,6 @@
 	)
 	(wire
 		(pts
-			(xy 59.69 27.94) (xy 59.69 29.21)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "3cce49d6-2e7e-4530-827e-d696ed7eeb5a")
-	)
-	(wire
-		(pts
 			(xy 12.7 118.11) (xy 19.05 118.11)
 		)
 		(stroke
@@ -5661,16 +5470,6 @@
 			(type default)
 		)
 		(uuid "3d5b0eb5-0c1c-444a-9fdd-bea1cf1d8439")
-	)
-	(wire
-		(pts
-			(xy 45.72 64.77) (xy 45.72 63.5)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "3e009935-67db-440f-be91-e3a0fb7e5c5e")
 	)
 	(wire
 		(pts
@@ -5691,16 +5490,6 @@
 			(type default)
 		)
 		(uuid "3faf6221-44eb-4cd7-aa9b-fcfdbc3ffe05")
-	)
-	(wire
-		(pts
-			(xy 63.5 63.5) (xy 83.82 63.5)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "42d6faab-3dfb-42c7-a3f9-22cfa2534242")
 	)
 	(wire
 		(pts
@@ -5754,16 +5543,6 @@
 	)
 	(wire
 		(pts
-			(xy 91.44 55.88) (xy 73.66 55.88)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "4b1a2665-38fe-4c06-a100-60f5259fb23b")
-	)
-	(wire
-		(pts
 			(xy 179.07 49.53) (xy 179.07 137.16)
 		)
 		(stroke
@@ -5781,16 +5560,6 @@
 			(type default)
 		)
 		(uuid "4c6d0ed7-a1d4-469b-a75b-46967230d04a")
-	)
-	(wire
-		(pts
-			(xy 66.04 62.23) (xy 83.82 62.23)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "4c8ed307-9508-4bee-9da7-486139d0a65d")
 	)
 	(wire
 		(pts
@@ -5844,16 +5613,6 @@
 	)
 	(wire
 		(pts
-			(xy 35.56 55.88) (xy 35.56 62.23)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "508dcce6-7d23-4d3c-8c54-f321b1866cd8")
-	)
-	(wire
-		(pts
 			(xy 86.36 171.45) (xy 86.36 138.43)
 		)
 		(stroke
@@ -5884,13 +5643,13 @@
 	)
 	(wire
 		(pts
-			(xy 60.96 34.29) (xy 60.96 35.56)
+			(xy 22.86 27.94) (xy 22.86 29.21)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "51aa9817-0374-41ba-85fd-467f06a2bc70")
+		(uuid "52f26ced-db89-4220-966b-240c27333483")
 	)
 	(wire
 		(pts
@@ -5954,6 +5713,16 @@
 	)
 	(wire
 		(pts
+			(xy 63.5 54.61) (xy 83.82 54.61)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5c8d4083-fcdd-4c3c-9afb-33542d322a08")
+	)
+	(wire
+		(pts
 			(xy 44.45 118.11) (xy 81.28 118.11)
 		)
 		(stroke
@@ -5981,16 +5750,6 @@
 			(type default)
 		)
 		(uuid "60fad20f-4d6a-45e1-b9f9-d6beabd8dbd7")
-	)
-	(wire
-		(pts
-			(xy 66.04 30.48) (xy 66.04 34.29)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "623f5303-b2cf-4566-8fee-54e405a72c38")
 	)
 	(wire
 		(pts
@@ -6034,6 +5793,16 @@
 	)
 	(wire
 		(pts
+			(xy 45.72 53.34) (xy 45.72 54.61)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "66c0eb46-60c8-4fe0-8211-04ef68b701b8")
+	)
+	(wire
+		(pts
 			(xy 217.17 133.35) (xy 217.17 123.19)
 		)
 		(stroke
@@ -6074,23 +5843,13 @@
 	)
 	(wire
 		(pts
-			(xy 25.4 55.88) (xy 25.4 66.04)
+			(xy 25.4 49.53) (xy 25.4 59.69)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "6b55e180-b3c5-4f8c-a95e-810baef9dd3a")
-	)
-	(wire
-		(pts
-			(xy 29.21 31.75) (xy 29.21 34.29)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "6d03ac42-5d0a-4ba8-bd31-3d189f181679")
 	)
 	(wire
 		(pts
@@ -6114,7 +5873,7 @@
 	)
 	(wire
 		(pts
-			(xy 45.72 33.02) (xy 45.72 34.29)
+			(xy 45.72 27.94) (xy 45.72 39.37)
 		)
 		(stroke
 			(width 0)
@@ -6141,16 +5900,6 @@
 			(type default)
 		)
 		(uuid "6e8a6b05-fd3a-45a2-aa84-c7161ba71951")
-	)
-	(wire
-		(pts
-			(xy 13.97 34.29) (xy 13.97 45.72)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "6ef8f257-363a-430d-8b0f-a4cae8b64243")
 	)
 	(wire
 		(pts
@@ -6224,16 +5973,6 @@
 	)
 	(wire
 		(pts
-			(xy 83.82 62.23) (xy 83.82 54.61)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "72f565c2-3d7b-46ad-838c-fed886c244a1")
-	)
-	(wire
-		(pts
 			(xy 69.85 95.25) (xy 93.98 95.25)
 		)
 		(stroke
@@ -6251,16 +5990,6 @@
 			(type default)
 		)
 		(uuid "73145c84-518f-42aa-bf70-c3b56a91b980")
-	)
-	(wire
-		(pts
-			(xy 45.72 34.29) (xy 45.72 45.72)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "7363fafb-d452-4c00-9c58-4920d10c8a02")
 	)
 	(wire
 		(pts
@@ -6294,16 +6023,6 @@
 	)
 	(wire
 		(pts
-			(xy 21.59 27.94) (xy 21.59 31.75)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "75f06ae0-5e37-463d-8dd6-dde81f9d00ed")
-	)
-	(wire
-		(pts
 			(xy 279.4 25.4) (xy 275.59 25.4)
 		)
 		(stroke
@@ -6311,16 +6030,6 @@
 			(type default)
 		)
 		(uuid "7656c7b6-327d-4ae0-b09e-39f7cc922709")
-	)
-	(wire
-		(pts
-			(xy 53.34 59.69) (xy 53.34 60.96)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "76915d80-59d1-4a0a-b5b7-2e3f174b2cfc")
 	)
 	(wire
 		(pts
@@ -6344,26 +6053,6 @@
 	)
 	(wire
 		(pts
-			(xy 59.69 29.21) (xy 59.69 30.48)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "7965b61c-4d96-48f2-9449-17250a7df5f3")
-	)
-	(wire
-		(pts
-			(xy 45.72 27.94) (xy 45.72 33.02)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "79a79008-6c30-427c-a5cc-7bf3a9184e45")
-	)
-	(wire
-		(pts
 			(xy 68.58 151.13) (xy 68.58 92.71)
 		)
 		(stroke
@@ -6384,33 +6073,13 @@
 	)
 	(wire
 		(pts
-			(xy 29.21 27.94) (xy 29.21 31.75)
+			(xy 66.04 27.94) (xy 66.04 29.21)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "7d75e082-b8fd-4d91-93d9-4022b6073c1b")
-	)
-	(wire
-		(pts
-			(xy 21.59 35.56) (xy 22.86 35.56)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "7e720ed0-d858-475a-bd5f-040714dd011c")
-	)
-	(wire
-		(pts
-			(xy 66.04 55.88) (xy 66.04 62.23)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "7ffa1c18-c692-4d7e-ba20-32c77011f66d")
+		(uuid "7d884cd8-cef3-4254-b6da-9b99aef47e5d")
 	)
 	(wire
 		(pts
@@ -6444,7 +6113,7 @@
 	)
 	(wire
 		(pts
-			(xy 53.34 45.72) (xy 53.34 52.07)
+			(xy 53.34 39.37) (xy 53.34 55.88)
 		)
 		(stroke
 			(width 0)
@@ -6494,6 +6163,16 @@
 	)
 	(wire
 		(pts
+			(xy 90.17 49.53) (xy 90.17 59.69)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "82e7388d-622b-43fc-a2b7-b48b1a31e1ab")
+	)
+	(wire
+		(pts
 			(xy 231.14 130.81) (xy 231.14 134.62)
 		)
 		(stroke
@@ -6514,16 +6193,6 @@
 	)
 	(wire
 		(pts
-			(xy 52.07 67.31) (xy 91.44 67.31)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "83bf7402-a9c6-4ced-a555-a9036ab2cb38")
-	)
-	(wire
-		(pts
 			(xy 92.71 165.1) (xy 92.71 153.67)
 		)
 		(stroke
@@ -6534,23 +6203,13 @@
 	)
 	(wire
 		(pts
-			(xy 25.4 66.04) (xy 90.17 66.04)
+			(xy 25.4 59.69) (xy 82.55 59.69)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "857eb341-44b8-4e19-b09e-cb06c11662d7")
-	)
-	(wire
-		(pts
-			(xy 27.94 55.88) (xy 27.94 64.77)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "85bba3b7-8fc2-46b0-bbbf-167afebd3890")
 	)
 	(wire
 		(pts
@@ -6614,16 +6273,6 @@
 	)
 	(wire
 		(pts
-			(xy 83.82 45.72) (xy 83.82 33.02)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "8a9a75c0-7fe5-464e-878e-46aaeb4a1758")
-	)
-	(wire
-		(pts
 			(xy 83.82 143.51) (xy 83.82 90.17)
 		)
 		(stroke
@@ -6631,6 +6280,16 @@
 			(type default)
 		)
 		(uuid "8be3a971-a9e9-41f8-9796-6660b903bd6b")
+	)
+	(wire
+		(pts
+			(xy 45.72 54.61) (xy 45.72 55.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8c6a3060-7eb5-4d6d-a9b3-c46203e2ac93")
 	)
 	(wire
 		(pts
@@ -6654,6 +6313,16 @@
 	)
 	(wire
 		(pts
+			(xy 45.72 55.88) (xy 45.72 57.15)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8fea89e5-bd41-41cc-b492-e59683c6b0f0")
+	)
+	(wire
+		(pts
 			(xy 66.04 154.94) (xy 66.04 166.37)
 		)
 		(stroke
@@ -6671,6 +6340,16 @@
 			(type default)
 		)
 		(uuid "92a17a5d-64ec-41ee-92b4-104cd8f59613")
+	)
+	(wire
+		(pts
+			(xy 63.5 49.53) (xy 63.5 54.61)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "92d551ef-0bca-4bb5-800d-75b7c604f2ae")
 	)
 	(wire
 		(pts
@@ -6694,7 +6373,17 @@
 	)
 	(wire
 		(pts
-			(xy 45.72 49.53) (xy 45.72 45.72)
+			(xy 73.66 49.53) (xy 73.66 52.07)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "953f6d63-15f5-4d7a-9a8e-ad7390f8748a")
+	)
+	(wire
+		(pts
+			(xy 45.72 39.37) (xy 45.72 53.34)
 		)
 		(stroke
 			(width 0)
@@ -6724,23 +6413,13 @@
 	)
 	(wire
 		(pts
-			(xy 15.24 67.31) (xy 52.07 67.31)
+			(xy 15.24 67.31) (xy 53.34 67.31)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "96efff82-90fe-4998-bf11-00963f16d62b")
-	)
-	(wire
-		(pts
-			(xy 21.59 31.75) (xy 21.59 34.29)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "97a200a7-4eeb-4a4f-bdf4-7a72f4687965")
 	)
 	(wire
 		(pts
@@ -6751,16 +6430,6 @@
 			(type default)
 		)
 		(uuid "9967714a-fdbd-43f6-853c-4de855145d61")
-	)
-	(wire
-		(pts
-			(xy 67.31 27.94) (xy 67.31 29.21)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "9a8c9f0e-86bf-49e9-a465-b675d37828ed")
 	)
 	(wire
 		(pts
@@ -6804,13 +6473,13 @@
 	)
 	(wire
 		(pts
-			(xy 93.98 52.07) (xy 91.44 52.07)
+			(xy 30.48 49.53) (xy 30.48 54.61)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "9dfa7d53-d338-430b-99b1-64ac80d13533")
+		(uuid "9e0256c3-12e2-43f1-88bc-865b86f5485f")
 	)
 	(wire
 		(pts
@@ -6844,23 +6513,23 @@
 	)
 	(wire
 		(pts
-			(xy 59.69 30.48) (xy 60.96 30.48)
+			(xy 27.94 55.88) (xy 45.72 55.88)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "9f5aa386-09bd-44a4-be11-f6e499a67675")
+		(uuid "9f90380e-81e3-40bf-88a6-751aadfc2693")
 	)
 	(wire
 		(pts
-			(xy 52.07 60.96) (xy 52.07 67.31)
+			(xy 30.48 54.61) (xy 45.72 54.61)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "a15a6a16-2f4b-4f6d-8658-e09148ac1061")
+		(uuid "a15a1fc8-2c6f-4017-944d-a0235c055861")
 	)
 	(wire
 		(pts
@@ -6931,6 +6600,16 @@
 			(type default)
 		)
 		(uuid "a6603c16-594a-4637-806b-3e6b2eb7a8e3")
+	)
+	(wire
+		(pts
+			(xy 53.34 55.88) (xy 53.34 67.31)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a696bbe6-06f7-47a1-97a4-836cc3cc61b9")
 	)
 	(wire
 		(pts
@@ -7021,16 +6700,6 @@
 			(type default)
 		)
 		(uuid "ad28cf4b-fa30-4968-952b-38cf39ddb00d")
-	)
-	(wire
-		(pts
-			(xy 21.59 34.29) (xy 21.59 35.56)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "ad4d182d-fd82-4532-a571-97c6ef077d91")
 	)
 	(wire
 		(pts
@@ -7144,13 +6813,23 @@
 	)
 	(wire
 		(pts
-			(xy 15.24 45.72) (xy 15.24 53.34)
+			(xy 35.56 49.53) (xy 35.56 53.34)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "b69681ea-7d6e-4e07-b291-a4af57deae35")
+		(uuid "b5de943f-b70b-4637-825a-26956cdebd86")
+	)
+	(wire
+		(pts
+			(xy 66.04 49.53) (xy 66.04 55.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b6ad627b-d58a-4f2d-850e-9f4a2e42dd31")
 	)
 	(wire
 		(pts
@@ -7161,6 +6840,16 @@
 			(type default)
 		)
 		(uuid "b74c2db2-e059-47fb-8747-8fd45397ef75")
+	)
+	(wire
+		(pts
+			(xy 35.56 53.34) (xy 45.72 53.34)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b75a439e-8e20-4684-9ca2-e6e9b9206e3c")
 	)
 	(wire
 		(pts
@@ -7214,6 +6903,16 @@
 	)
 	(wire
 		(pts
+			(xy 90.17 49.53) (xy 93.98 49.53)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bebeaaa9-20e2-4410-9a91-13e80b8b26cf")
+	)
+	(wire
+		(pts
 			(xy 255.27 157.48) (xy 162.56 157.48)
 		)
 		(stroke
@@ -7231,6 +6930,16 @@
 			(type default)
 		)
 		(uuid "c1035bbf-ce56-43be-9b47-1784223c89b1")
+	)
+	(wire
+		(pts
+			(xy 27.94 27.94) (xy 27.94 29.21)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c191ae12-fa30-4082-b38a-708edc7cf10c")
 	)
 	(wire
 		(pts
@@ -7324,6 +7033,26 @@
 	)
 	(wire
 		(pts
+			(xy 83.82 57.15) (xy 45.72 57.15)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c94e9600-8ff9-4513-abf0-477a7d89bc39")
+	)
+	(wire
+		(pts
+			(xy 73.66 52.07) (xy 74.93 52.07)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c9c4da66-8641-4331-b088-fb58ccf66695")
+	)
+	(wire
+		(pts
 			(xy 77.47 77.47) (xy 93.98 77.47)
 		)
 		(stroke
@@ -7331,6 +7060,16 @@
 			(type default)
 		)
 		(uuid "ca2ad16a-6451-455a-acfc-8b90060dfcd7")
+	)
+	(wire
+		(pts
+			(xy 68.58 49.53) (xy 68.58 55.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cb6ac180-cf25-4688-bb64-aae138da1cda")
 	)
 	(wire
 		(pts
@@ -7354,16 +7093,6 @@
 	)
 	(wire
 		(pts
-			(xy 45.72 62.23) (xy 45.72 57.15)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "cbeb9d5a-4ab3-4e29-a371-455079f73d39")
-	)
-	(wire
-		(pts
 			(xy 199.39 52.07) (xy 199.39 49.53)
 		)
 		(stroke
@@ -7374,13 +7103,13 @@
 	)
 	(wire
 		(pts
-			(xy 66.04 34.29) (xy 66.04 35.56)
+			(xy 83.82 54.61) (xy 83.82 57.15)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "cc8f31ab-62d3-4ee6-9b9f-7abf90e37b3e")
+		(uuid "cd00e6ed-b8ae-4c55-89d6-d636d9d741cf")
 	)
 	(wire
 		(pts
@@ -7421,16 +7150,6 @@
 			(type default)
 		)
 		(uuid "cedaa257-cdb6-4d2b-bfc1-17b529493a87")
-	)
-	(wire
-		(pts
-			(xy 30.48 63.5) (xy 45.72 63.5)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "cf854231-38f1-4be2-b531-0d123d5f3b78")
 	)
 	(wire
 		(pts
@@ -7544,6 +7263,16 @@
 	)
 	(wire
 		(pts
+			(xy 66.04 55.88) (xy 53.34 55.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d6914619-1e31-466b-af37-63dbf1dddcb2")
+	)
+	(wire
+		(pts
 			(xy 248.92 93.98) (xy 251.46 93.98)
 		)
 		(stroke
@@ -7551,6 +7280,16 @@
 			(type default)
 		)
 		(uuid "d6a7750c-353e-47d9-ae9a-a35fca9e8ea8")
+	)
+	(wire
+		(pts
+			(xy 82.55 52.07) (xy 93.98 52.07)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d6b41481-3f7b-4902-904e-9953e4956df3")
 	)
 	(wire
 		(pts
@@ -7584,16 +7323,6 @@
 	)
 	(wire
 		(pts
-			(xy 63.5 55.88) (xy 63.5 63.5)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "d9134198-0ba2-4fa3-86eb-fe1c4294f262")
-	)
-	(wire
-		(pts
 			(xy 194.31 69.85) (xy 194.31 67.31)
 		)
 		(stroke
@@ -7624,16 +7353,6 @@
 	)
 	(wire
 		(pts
-			(xy 36.83 34.29) (xy 45.72 34.29)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "db49cacf-14bb-4758-9391-4230860e54f7")
-	)
-	(wire
-		(pts
 			(xy 171.45 166.37) (xy 171.45 161.29)
 		)
 		(stroke
@@ -7641,16 +7360,6 @@
 			(type default)
 		)
 		(uuid "db8abd1c-5bdf-468b-bdd3-1ad7ada4e504")
-	)
-	(wire
-		(pts
-			(xy 73.66 33.02) (xy 73.66 34.29)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "dc26aab1-815d-4710-80c0-21b88c72e358")
 	)
 	(wire
 		(pts
@@ -7694,7 +7403,7 @@
 	)
 	(wire
 		(pts
-			(xy 15.24 60.96) (xy 15.24 67.31)
+			(xy 15.24 39.37) (xy 15.24 67.31)
 		)
 		(stroke
 			(width 0)
@@ -7704,7 +7413,7 @@
 	)
 	(wire
 		(pts
-			(xy 83.82 46.99) (xy 83.82 45.72)
+			(xy 83.82 39.37) (xy 83.82 54.61)
 		)
 		(stroke
 			(width 0)
@@ -7721,16 +7430,6 @@
 			(type default)
 		)
 		(uuid "e0755a40-a2fa-4411-bd15-98201d9b5e2a")
-	)
-	(wire
-		(pts
-			(xy 73.66 33.02) (xy 45.72 33.02)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "e1ea81ba-8054-436f-bbc3-80f2b5690496")
 	)
 	(wire
 		(pts
@@ -7864,13 +7563,13 @@
 	)
 	(wire
 		(pts
-			(xy 83.82 33.02) (xy 73.66 33.02)
+			(xy 60.96 27.94) (xy 60.96 29.21)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "eb9e85c5-8e56-425a-9e34-f009f028c016")
+		(uuid "eb0e8201-f47e-4f21-aee4-32d485f444b2")
 	)
 	(wire
 		(pts
@@ -7994,16 +7693,6 @@
 	)
 	(wire
 		(pts
-			(xy 53.34 60.96) (xy 52.07 60.96)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "f68c348f-4240-4b38-9edf-20974aaef8d0")
-	)
-	(wire
-		(pts
 			(xy 278.13 41.91) (xy 278.13 30.48)
 		)
 		(stroke
@@ -8011,16 +7700,6 @@
 			(type default)
 		)
 		(uuid "f8dda364-9fcd-4dbe-87d9-aa763896e316")
-	)
-	(wire
-		(pts
-			(xy 29.21 34.29) (xy 29.21 35.56)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "f9dcf423-f6c3-482f-9078-2a38ab3b28ef")
 	)
 	(wire
 		(pts
@@ -8074,16 +7753,6 @@
 	)
 	(wire
 		(pts
-			(xy 91.44 52.07) (xy 91.44 55.88)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "feac5dbc-fd6e-4a10-b79f-ff2616e15e1e")
-	)
-	(wire
-		(pts
 			(xy 229.87 92.71) (xy 231.14 92.71)
 		)
 		(stroke
@@ -8091,16 +7760,6 @@
 			(type default)
 		)
 		(uuid "feb01471-8401-4acc-9ce8-3c60dec016e9")
-	)
-	(wire
-		(pts
-			(xy 90.17 49.53) (xy 93.98 49.53)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "ff1be35b-3c72-4913-a462-7dafc95e29d7")
 	)
 	(image
 		(at 186.69 173.99)
@@ -11916,7 +11575,7 @@
 	)
 	(global_label "RS485 TX A"
 		(shape input)
-		(at 59.69 27.94 90)
+		(at 60.96 27.94 90)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -11926,7 +11585,7 @@
 		)
 		(uuid "1ed1314c-dad3-46c1-a8ad-c2d7e11130c1")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 59.69 13.3435 90)
+			(at 60.96 13.3435 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11938,7 +11597,7 @@
 	)
 	(global_label "RS485 TX B"
 		(shape input)
-		(at 67.31 27.94 90)
+		(at 66.04 27.94 90)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -11948,7 +11607,7 @@
 		)
 		(uuid "3b8c733a-57e2-4927-8c6a-b625b8a40559")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 67.31 13.3435 90)
+			(at 66.04 13.3435 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11982,7 +11641,7 @@
 	)
 	(global_label "RS485 RX A"
 		(shape input)
-		(at 21.59 27.94 90)
+		(at 22.86 27.94 90)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -11992,7 +11651,7 @@
 		)
 		(uuid "64477464-f68c-40f6-9fd8-ca835251569e")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 21.59 13.3435 90)
+			(at 22.86 13.3435 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -12048,7 +11707,7 @@
 	)
 	(global_label "RS485 RX B"
 		(shape input)
-		(at 29.21 27.94 90)
+		(at 27.94 27.94 90)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -12058,7 +11717,7 @@
 		)
 		(uuid "f220419c-d220-48a8-bdb3-531e6b0f7898")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 29.21 13.3435 90)
+			(at 27.94 13.3435 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -12138,7 +11797,6 @@
 		)
 	)
 	(symbol
-		(lib_name "5VRelay:5V_Relay")
 		(lib_id "5VRelay:5V_Relay")
 		(at 271.78 146.05 0)
 		(unit 1)
@@ -12221,283 +11879,6 @@
 		)
 	)
 	(symbol
-		(lib_id "Device:C")
-		(at 15.24 57.15 0)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(uuid "0db623a1-f596-4983-9d1f-81f6976325d0")
-		(property "Reference" "C1"
-			(at 15.494 55.118 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-			)
-		)
-		(property "Value" "0.1uF"
-			(at 15.494 59.182 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-			)
-		)
-		(property "Footprint" ""
-			(at 16.2052 60.96 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 15.24 57.15 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Unpolarized capacitor"
-			(at 15.24 57.15 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "2"
-			(uuid "fc9d27ee-204f-4c95-9354-fc90ef3d0f64")
-		)
-		(pin "1"
-			(uuid "b21c0a7e-a4a7-4f1d-b9d3-55c5b3718464")
-		)
-		(instances
-			(project ""
-				(path "/4e05caf8-77e4-4a22-9a05-51fcca8e50ff"
-					(reference "C1")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "Device:R")
-		(at 17.78 34.29 90)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "0e4edc41-47c2-4229-8a56-a48238881e81")
-		(property "Reference" "R6"
-			(at 17.78 27.94 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Value" "680"
-			(at 17.78 30.48 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 17.78 36.068 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 17.78 34.29 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Resistor"
-			(at 17.78 34.29 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "afbcd6cb-06d9-4d05-b4a0-457c90dac6d7")
-		)
-		(pin "2"
-			(uuid "463f158d-06ee-4924-a033-953402d6e8d8")
-		)
-		(instances
-			(project "Systems&Electronics"
-				(path "/4e05caf8-77e4-4a22-9a05-51fcca8e50ff"
-					(reference "R6")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "Device:R")
-		(at 45.72 53.34 180)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "14e41f02-3d78-4a9b-8235-12c11e45f75b")
-		(property "Reference" "R3"
-			(at 48.26 52.0699 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Value" "10k"
-			(at 48.26 54.6099 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Footprint" ""
-			(at 47.498 53.34 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 45.72 53.34 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Resistor"
-			(at 45.72 53.34 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "2"
-			(uuid "b22c3521-7fba-44da-bddc-525556448471")
-		)
-		(pin "1"
-			(uuid "77afee53-d5fa-49cd-82c0-954eb8edc7a5")
-		)
-		(instances
-			(project "Systems&Electronics"
-				(path "/4e05caf8-77e4-4a22-9a05-51fcca8e50ff"
-					(reference "R3")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "Device:C")
-		(at 53.34 55.88 180)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(uuid "179bc8b0-4e9d-457f-ba7f-1597c14021a4")
-		(property "Reference" "C2"
-			(at 53.34 53.848 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Value" "0.1uF"
-			(at 53.594 57.912 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Footprint" ""
-			(at 52.3748 52.07 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 53.34 55.88 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Unpolarized capacitor"
-			(at 53.34 55.88 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "007279d9-cf8e-4aeb-8fdf-f5aed2262723")
-		)
-		(pin "2"
-			(uuid "d4f5c1a3-232f-49b0-bfb5-a21524837af1")
-		)
-		(instances
-			(project ""
-				(path "/4e05caf8-77e4-4a22-9a05-51fcca8e50ff"
-					(reference "C2")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_name "5VRelay:5V_Relay")
 		(lib_id "5VRelay:5V_Relay")
 		(at 194.31 146.05 0)
 		(unit 1)
@@ -12714,74 +12095,6 @@
 			(project "Systems&Electronics"
 				(path "/4e05caf8-77e4-4a22-9a05-51fcca8e50ff"
 					(reference "R21")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "Device:R")
-		(at 57.15 34.29 90)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "31620227-0da8-4ab7-b071-7cef3f81050a")
-		(property "Reference" "R8"
-			(at 57.15 27.94 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Value" "680"
-			(at 57.15 30.48 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 57.15 36.068 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 57.15 34.29 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Resistor"
-			(at 57.15 34.29 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "fa3acc94-179d-4fff-87e0-1ad6f53ef319")
-		)
-		(pin "2"
-			(uuid "cf348b41-65e8-45b8-bdfb-2fb0162401c9")
-		)
-		(instances
-			(project "Systems&Electronics"
-				(path "/4e05caf8-77e4-4a22-9a05-51fcca8e50ff"
-					(reference "R8")
 					(unit 1)
 				)
 			)
@@ -13193,7 +12506,6 @@
 		)
 	)
 	(symbol
-		(lib_name "5VRelay:5V_Relay")
 		(lib_id "5VRelay:5V_Relay")
 		(at 199.39 59.69 0)
 		(unit 1)
@@ -13270,73 +12582,6 @@
 			(project "Systems&Electronics"
 				(path "/4e05caf8-77e4-4a22-9a05-51fcca8e50ff"
 					(reference "5V Relay4")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "Device:R")
-		(at 58.42 60.96 270)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(uuid "558c8b70-c845-4f90-a0c4-609b95229a77")
-		(property "Reference" "R1"
-			(at 58.42 63.246 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Value" "10k"
-			(at 58.42 60.96 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 58.42 59.182 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 58.42 60.96 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Resistor"
-			(at 58.42 60.96 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "2"
-			(uuid "90db129b-557c-4293-ad07-1bb14605e526")
-		)
-		(pin "1"
-			(uuid "f0c51493-9b06-4cce-8c91-b69e9fc6bc87")
-		)
-		(instances
-			(project ""
-				(path "/4e05caf8-77e4-4a22-9a05-51fcca8e50ff"
-					(reference "R1")
 					(unit 1)
 				)
 			)
@@ -13480,7 +12725,6 @@
 		)
 	)
 	(symbol
-		(lib_name "Solenoids:Solenoid")
 		(lib_id "Solenoids:Solenoid")
 		(at 273.05 128.27 0)
 		(unit 1)
@@ -13635,7 +12879,6 @@
 		)
 	)
 	(symbol
-		(lib_name "Solenoids:Solenoid")
 		(lib_id "Solenoids:Solenoid")
 		(at 251.46 128.27 0)
 		(unit 1)
@@ -13704,7 +12947,6 @@
 		)
 	)
 	(symbol
-		(lib_name "5VRelay:5V_Relay")
 		(lib_id "5VRelay:5V_Relay")
 		(at 222.25 146.05 0)
 		(unit 1)
@@ -13787,75 +13029,6 @@
 		)
 	)
 	(symbol
-		(lib_id "Device:R")
-		(at 33.02 34.29 90)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "72737501-6c08-4806-8f19-1be5d766fbec")
-		(property "Reference" "R7"
-			(at 33.02 27.94 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Value" "680"
-			(at 33.02 30.48 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 33.02 36.068 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 33.02 34.29 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Resistor"
-			(at 33.02 34.29 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "7a608437-a4c4-4103-93e8-bcf136588523")
-		)
-		(pin "2"
-			(uuid "8b52b339-e0e3-445c-977e-ac0ddce9b74a")
-		)
-		(instances
-			(project "Systems&Electronics"
-				(path "/4e05caf8-77e4-4a22-9a05-51fcca8e50ff"
-					(reference "R7")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_name "5VRelay:5V_Relay")
 		(lib_id "5VRelay:5V_Relay")
 		(at 250.19 146.05 0)
 		(unit 1)
@@ -14008,7 +13181,6 @@
 		)
 	)
 	(symbol
-		(lib_name "Solenoids:Solenoid")
 		(lib_id "Solenoids:Solenoid")
 		(at 195.58 128.27 0)
 		(unit 1)
@@ -14601,7 +13773,7 @@
 	)
 	(symbol
 		(lib_id "Interface_UART:MAX485E")
-		(at 30.48 45.72 90)
+		(at 30.48 39.37 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -14610,7 +13782,7 @@
 		(fields_autoplaced yes)
 		(uuid "a434582f-733a-4e1f-92be-8869bfe18d62")
 		(property "Reference" "U3"
-			(at 49.53 40.2238 90)
+			(at 49.53 33.8738 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -14618,7 +13790,7 @@
 			)
 		)
 		(property "Value" "MAX485E"
-			(at 49.53 42.7638 90)
+			(at 49.53 36.4138 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -14626,7 +13798,7 @@
 			)
 		)
 		(property "Footprint" "Package_SO:SOIC-8_3.9x4.9mm_P1.27mm"
-			(at 53.34 45.72 0)
+			(at 53.34 39.37 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -14635,7 +13807,7 @@
 			)
 		)
 		(property "Datasheet" "https://datasheets.maximintegrated.com/en/ds/MAX1487E-MAX491E.pdf"
-			(at 29.21 45.72 0)
+			(at 29.21 39.37 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -14644,7 +13816,7 @@
 			)
 		)
 		(property "Description" "Half duplex RS-485/RS-422, 2.5 Mbps, ±15kV electro-static discharge (ESD) protection, no slew-rate, no low-power shutdown, with receiver/driver enable, 32 receiver drive capability, DIP-8 and SOIC-8"
-			(at 30.48 45.72 0)
+			(at 30.48 39.37 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -14824,6 +13996,92 @@
 		)
 	)
 	(symbol
+		(lib_id "Device:D")
+		(at 86.36 59.69 180)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "b2dac434-a764-46e7-8eba-8dd084b57a5d")
+		(property "Reference" "D7"
+			(at 86.36 57.404 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "D"
+			(at 86.36 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 86.36 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 86.36 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode"
+			(at 86.36 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 86.36 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 86.36 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "354714f2-67f3-4fa9-9ce0-de380eea04af")
+		)
+		(pin "2"
+			(uuid "dcf0f41d-3c00-47c6-91f3-c2815e7d5b8d")
+		)
+		(instances
+			(project ""
+				(path "/4e05caf8-77e4-4a22-9a05-51fcca8e50ff"
+					(reference "D7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "Device:R")
 		(at 234.95 107.95 90)
 		(unit 1)
@@ -14888,74 +14146,6 @@
 			(project ""
 				(path "/4e05caf8-77e4-4a22-9a05-51fcca8e50ff"
 					(reference "R19")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "Device:R")
-		(at 63.5 29.21 90)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "baae82ca-ee0c-4f7f-8744-232eb95a1aa0")
-		(property "Reference" "R5"
-			(at 63.5 22.86 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Value" "120"
-			(at 63.5 25.4 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 63.5 30.988 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 63.5 29.21 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Resistor"
-			(at 63.5 29.21 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "617ac8e6-0be2-42e4-931c-6fb9939c2f5e")
-		)
-		(pin "2"
-			(uuid "ff98695c-6401-4137-987b-10048cf1e885")
-		)
-		(instances
-			(project "Systems&Electronics"
-				(path "/4e05caf8-77e4-4a22-9a05-51fcca8e50ff"
-					(reference "R5")
 					(unit 1)
 				)
 			)
@@ -15244,76 +14434,6 @@
 		)
 	)
 	(symbol
-		(lib_id "Device:R")
-		(at 83.82 50.8 180)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "d202e297-28d4-4e8e-98e9-3b8f159d3205")
-		(property "Reference" "R2"
-			(at 86.36 49.5299 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Value" "10k"
-			(at 86.36 52.0699 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Footprint" ""
-			(at 85.598 50.8 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 83.82 50.8 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Resistor"
-			(at 83.82 50.8 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "2"
-			(uuid "0e6b6b53-1b5d-48ea-9895-09b548f37197")
-		)
-		(pin "1"
-			(uuid "cd6bb867-54b6-4d4f-a4da-d7e6b97135e8")
-		)
-		(instances
-			(project "Systems&Electronics"
-				(path "/4e05caf8-77e4-4a22-9a05-51fcca8e50ff"
-					(reference "R2")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
 		(lib_id "Sensor_Temperature:AD8495")
 		(at 20.32 163.83 90)
 		(unit 1)
@@ -15489,74 +14609,6 @@
 	)
 	(symbol
 		(lib_id "Device:R")
-		(at 25.4 31.75 90)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "e244251c-4bc9-4f4e-8a93-1c898847303b")
-		(property "Reference" "R4"
-			(at 25.4 25.4 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Value" "120"
-			(at 25.4 27.94 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 25.4 33.528 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 25.4 31.75 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Resistor"
-			(at 25.4 31.75 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "595842ac-b2ae-4f27-a97d-8f567265c58f")
-		)
-		(pin "2"
-			(uuid "2bbc819e-94d1-40a4-8812-4c4324845206")
-		)
-		(instances
-			(project ""
-				(path "/4e05caf8-77e4-4a22-9a05-51fcca8e50ff"
-					(reference "R4")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "Device:R")
 		(at 234.95 93.98 90)
 		(unit 1)
 		(exclude_from_sim no)
@@ -15626,75 +14678,6 @@
 		)
 	)
 	(symbol
-		(lib_id "Device:R")
-		(at 69.85 34.29 90)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "ea3b6148-ff63-44b0-b862-89559ddb789a")
-		(property "Reference" "R9"
-			(at 69.85 27.94 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Value" "680"
-			(at 69.85 30.48 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 69.85 36.068 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 69.85 34.29 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Resistor"
-			(at 69.85 34.29 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "5651798b-c21c-47ec-89d8-4809a0391ea1")
-		)
-		(pin "2"
-			(uuid "352a7f2b-8344-47bb-9a29-51f32a1a87b8")
-		)
-		(instances
-			(project "Systems&Electronics"
-				(path "/4e05caf8-77e4-4a22-9a05-51fcca8e50ff"
-					(reference "R9")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_name "Solenoids:Solenoid")
 		(lib_id "Solenoids:Solenoid")
 		(at 223.52 128.27 0)
 		(unit 1)
@@ -15898,8 +14881,94 @@
 		)
 	)
 	(symbol
+		(lib_id "Device:D")
+		(at 78.74 52.07 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "fc2d4b28-9998-4ee8-917c-e5d376f5e71c")
+		(property "Reference" "D8"
+			(at 78.74 50.038 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "D"
+			(at 78.74 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode"
+			(at 78.74 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 78.74 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 78.74 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2dd01b2a-06d0-4614-b603-79fad99b9055")
+		)
+		(pin "2"
+			(uuid "1394bb1d-ebec-48ec-9208-7e9b4e1c7a53")
+		)
+		(instances
+			(project "Systems&Electronics"
+				(path "/4e05caf8-77e4-4a22-9a05-51fcca8e50ff"
+					(reference "D8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "Interface_UART:MAX485E")
-		(at 68.58 45.72 90)
+		(at 68.58 39.37 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -15908,7 +14977,7 @@
 		(fields_autoplaced yes)
 		(uuid "ffa71b13-1921-4d88-9f4c-5e8f1cc0b7c0")
 		(property "Reference" "U4"
-			(at 87.63 40.2238 90)
+			(at 87.63 33.8738 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -15916,7 +14985,7 @@
 			)
 		)
 		(property "Value" "MAX485E"
-			(at 87.63 42.7638 90)
+			(at 87.63 36.4138 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -15924,7 +14993,7 @@
 			)
 		)
 		(property "Footprint" "Package_SO:SOIC-8_3.9x4.9mm_P1.27mm"
-			(at 91.44 45.72 0)
+			(at 91.44 39.37 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -15933,7 +15002,7 @@
 			)
 		)
 		(property "Datasheet" "https://datasheets.maximintegrated.com/en/ds/MAX1487E-MAX491E.pdf"
-			(at 67.31 45.72 0)
+			(at 67.31 39.37 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -15942,7 +15011,7 @@
 			)
 		)
 		(property "Description" "Half duplex RS-485/RS-422, 2.5 Mbps, ±15kV electro-static discharge (ESD) protection, no slew-rate, no low-power shutdown, with receiver/driver enable, 32 receiver drive capability, DIP-8 and SOIC-8"
-			(at 68.58 45.72 0)
+			(at 68.58 39.37 0)
 			(effects
 				(font
 					(size 1.27 1.27)

--- a/KiCad/~Systems&Electronics.kicad_sch.lck
+++ b/KiCad/~Systems&Electronics.kicad_sch.lck
@@ -1,1 +1,1 @@
-{"hostname":"COOPLAPTOP","username":"coope"}
+{"hostname":"COOPERS-DESKTOP","username":"coope"}


### PR DESCRIPTION
So I recently discovered that the RS485 boards we are using already have the resistors and capacitors that we need... this removes those redundant components from the schematic.

# DO NOT MERGE UNTIL TESTED AND VERIFIED IN LAB 

^^^ (mostly a note for myself)